### PR TITLE
Expose LUIRoot from LUIRegion

### DIFF
--- a/source/luiRegion.I
+++ b/source/luiRegion.I
@@ -15,6 +15,10 @@ INLINE LUIObject* LUIRegion::get_root() const {
   return _lui_root->node();
 }
 
+INLINE LUIRoot* LUIRegion::get_root_instance() const {
+  return _lui_root;
+}
+
 INLINE void LUIRegion::set_input_handler(LUIInputHandler* handler) {
   _input_handler = handler;
 }

--- a/source/luiRegion.h
+++ b/source/luiRegion.h
@@ -45,6 +45,8 @@ PUBLISHED:
                                    const LVecBase4& dimensions);
   INLINE LUIObject* get_root() const;
 
+  INLINE LUIRoot* get_root_instance() const;
+
   MAKE_PROPERTY(root, get_root);
 
   INLINE void set_input_handler(LUIInputHandler* handler);


### PR DESCRIPTION
Provides way to get the root instance of the region, so that 'set_use_glsl_130' is available