### PR TITLE
Add sprite tiling

### DIFF
--- a/Builtin/LUISelectbox.py
+++ b/Builtin/LUISelectbox.py
@@ -193,7 +193,7 @@ class LUISelectdrop(LUIObject):
             opt_bg.bind("click", partial(self._on_opt_click, opt_id))
             opt_bg.solid = True
 
-            opt_label = LUILabel(parent=opt_container, text=opt_val.encode('utf-8'))
+            opt_label = LUILabel(parent=opt_container, text=str(opt_val))
             opt_label.top = 8
             opt_label.left = 8
 

--- a/Demos/B_InputField.py
+++ b/Demos/B_InputField.py
@@ -19,9 +19,14 @@ f.construct_sourcecode("LUIInputField")
 # Create 2 new buttons, and store them in a vertical layout
 field = LUIInputField(parent=f.get_widget_node())
 
+def setRandomText(field):
+    """ Sets a random text in the input field """
+    field.value = f"Text: {random.randint(100, 10000000)}"
+
+
 f.set_actions({
-        "Set Random Text": lambda: field.set_value(u"Text: " + unicode(random.randint(100, 10000000))),
+        "Set Random Text": lambda: setRandomText(field),
         "Clear": lambda: field.clear(),
     })
 
-run()
+base.run()

--- a/source/luiRegion.cxx
+++ b/source/luiRegion.cxx
@@ -1,5 +1,3 @@
-
-
 #include "luiRegion.h"
 
 

--- a/source/luiSprite.I
+++ b/source/luiSprite.I
@@ -131,3 +131,11 @@ INLINE void LUISprite::init_size(float w, float h) {
   else if (h > 0.0)
     set_height(h);
 }
+
+INLINE void LUISprite::set_wrap_texture(bool wrap) {
+  _wrap_texture = wrap;
+}
+
+INLINE bool LUISprite::get_wrap_texture() const {
+  return _wrap_texture;
+}

--- a/source/luiSprite.h
+++ b/source/luiSprite.h
@@ -73,6 +73,9 @@ PUBLISHED:
 
   INLINE void print_vertices();
 
+  INLINE void set_wrap_texture(bool wrap);
+  INLINE bool get_wrap_texture() const;
+
   void ls(int indent = 0);
 
   // Python properties
@@ -135,6 +138,7 @@ public:
 
 private:
   static TypeHandle _type_handle;
+  bool _wrap_texture;
 };
 
 

--- a/source/luiVertexData.h
+++ b/source/luiVertexData.h
@@ -11,11 +11,16 @@
 
 #include <stdint.h>
 
-struct LUIVertexData {
-  float x, y, z;
-  unsigned char color[4];
-  float u, v;
-  uint16_t texindex;
+struct alignas(16) LUIVertexData {
+  float x, y, z;                           // 12 bytes
+  float u, v;                              // 8 bytes
+  float atlas_u1, atlas_v1;                // 8 bytes (aligned to 4 bytes)
+  float subregion_u_width, subregion_v_height;  // 8 bytes (aligned to 4 bytes)
+
+  unsigned char color[4];                  // 4 bytes
+  uint16_t texindex;                       // 2 bytes
+  int32_t wrap_flag;                       // 4 byte
+  unsigned char padding[6];                // 6 bytes
 };
 
 #endif


### PR DESCRIPTION
* Adds set_wrap_texture method to Sprites.  Set to true to tile the texture across the width and height of the sprite.
* Fixes some python 3 issues