### PR TITLE
Fix wrap sprites when scrolling

### DIFF
--- a/source/luiRegion.cxx
+++ b/source/luiRegion.cxx
@@ -78,8 +78,14 @@ void LUIRegion::
           shaderAttrib = DCAST(ShaderAttrib, shaderAttrib)->set_shader_input(
             InternalName::make(sstm.str()), _empty_tex);
       }
-
     }
+
+    shaderAttrib = DCAST(ShaderAttrib, shaderAttrib)->set_shader_input(
+      InternalName::make("screen_width"), _width
+    );
+    shaderAttrib = DCAST(ShaderAttrib, shaderAttrib)->set_shader_input(
+      InternalName::make("screen_height"), _height
+    );
 
     shaderAttrib = DCAST(ShaderAttrib, shaderAttrib)->set_shader(_object_shader);
 

--- a/source/luiSprite.cxx
+++ b/source/luiSprite.cxx
@@ -241,12 +241,20 @@ void LUISprite::recompute_vertices() {
 
   // Handle scaling to actual pixel size if _wrap_texture is enabled
   if (_wrap_texture) {
+    _data[0].x = x1;
+    _data[0].z = y1;
+    _data[1].x = x2;
+    _data[1].z = y1;
+    _data[2].x = x2;
+    _data[2].z = y2;
+    _data[3].x = x1;
+    _data[3].z = y2;
+
     float sprite_width = _effective_size.get_x();
     float sprite_height = _effective_size.get_y();
 
-    // Scale UVs based on the clipped region
-    float scaled_u_width = clipped_width / texture_width;
-    float scaled_v_height = clipped_height / texture_height;
+    float scaled_u_width = sprite_width / texture_width;
+    float scaled_v_height = sprite_height / texture_height;
 
     // Wrap UVs within the clipped region
     u1 = fmod(u1, scaled_u_width);
@@ -274,11 +282,15 @@ void LUISprite::recompute_vertices() {
   for (int i = 0; i < 4; i++) {
     _data[i].y = 0;
     _data[i].texindex = static_cast<uint16_t>(_texture_index);
-    _data[i].atlas_u1 = u1;
-    _data[i].atlas_v1 = 1.0f - (v1);
+    _data[i].atlas_u1 = _uv_begin.get_x() + ROUND_MARGIN;
+    _data[i].atlas_v1 = 1.0f - (_uv_begin.get_y() + ROUND_MARGIN);
     _data[i].subregion_u_width = atlas_width;
     _data[i].subregion_v_height = -(atlas_height);
     _data[i].wrap_flag = _wrap_texture ? 1 : 0; // Set wrap_flag based on _wrap_texture
+    _data[i].clip_x1 = bnds_x1;
+    _data[i].clip_y1 = bnds_y1;
+    _data[i].clip_x2 = bnds_x2;
+    _data[i].clip_y2 = bnds_y2;
   }
 
   for (int i = 0; i < 4; i++) {

--- a/source/luiVertexData.h
+++ b/source/luiVertexData.h
@@ -16,10 +16,10 @@ struct alignas(16) LUIVertexData {
   float u, v;                              // 8 bytes
   float atlas_u1, atlas_v1;                // 8 bytes (aligned to 4 bytes)
   float subregion_u_width, subregion_v_height;  // 8 bytes (aligned to 4 bytes)
-
   unsigned char color[4];                  // 4 bytes
   uint16_t texindex;                       // 2 bytes
   int32_t wrap_flag;                       // 4 byte
+  float clip_x1, clip_y1, clip_x2, clip_y2; // 16 bytes
   unsigned char padding[6];                // 6 bytes
 };
 


### PR DESCRIPTION
* When scrolling with wrapped sprites, the sprite texture wouldn't move
* This was because the polygon itself doesn't move, but is clipped
* This changes the behaviour so the polygon translates, and is clipped by the shader outside of the clipping bounds